### PR TITLE
fixed an unglueFumen bug caused by default JS sorting

### DIFF
--- a/modified-unglueFumen.js
+++ b/modified-unglueFumen.js
@@ -117,7 +117,7 @@ function unglueFumen() {
                 for (let row of temp) {
                     if (!rowsCleared.includes(row)) {
                         rowsCleared.push(row);
-                        rowsCleared.sort();
+						rowsCleared.sort(function(a,b){return a-b});
                     }
                 }
             

--- a/unglueFumen.js
+++ b/unglueFumen.js
@@ -112,7 +112,7 @@ for (let code of fumenCodes) {
         for (let row of temp) {
             if (!rowsCleared.includes(row)) {
                 rowsCleared.push(row);
-                rowsCleared.sort();
+                rowsCleared.sort(function(a,b){return a-b});
             }
         }
         


### PR DESCRIPTION
## Issue
`unglueFumen.js` puts pieces one row lower than the correct position if more than 10 lines are cleared.

## Fix
Changed from the default sorting with lexicographical ordering:
```JS
rowsCleared.sort();
```
to the correct sorting with numeric ordering:
```JS
rowsCleared.sort(function(a,b)=>{return a-b;});
```